### PR TITLE
Fix input event when v-model is in array of objects

### DIFF
--- a/src/component.vue
+++ b/src/component.vue
@@ -62,7 +62,10 @@
        */
       onValueChanged(event) {
         let value = this.raw ? event.target.rawValue : event.target.value;
-        this.$emit('input', value);
+
+        if (this.value !== value) {
+          this.$emit('input', value);
+        }
 
         // Call original callback method
         if (typeof this.onValueChangedFn === 'function') {


### PR DESCRIPTION
Using Сleave and VeeValidate in the array of objects makes fields invalid during initialization. 
This happens because the “input” event occurs. 
Example: [https://jsfiddle.net/xbebopx/maL7fp0u/1/](https://jsfiddle.net/xbebopx/maL7fp0u/1/)