### PR TITLE
Revert "Correct syntax highlighting for Vue snippets."

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ yarn add vue-cleave-component
 ```
 
 ## Usage
-```vue
+```html
 <template>
   <div>
     <cleave v-model="cardNumber" :options="options" class="form-control" name="card"></cleave>
@@ -88,7 +88,7 @@ The component accepts these props:
 <script src="https://cdn.jsdelivr.net/npm/vue-cleave-component@2"></script>
 ```
 * Use the component anywhere in your app like this
-```vue
+```html
 <main id="app">  
     <cleave v-model="card" :options="options"></cleave> 
 </main>
@@ -125,7 +125,7 @@ Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recen
 
 ## Caveats
 * :warning: Don't pass config option as inline literal object to `:options` prop.
-```vue
+```html
 <!-- This will cause an infinite loop -->
 <cleave v-model="card" :options="{creditCard:true}"></cleave>
 ```


### PR DESCRIPTION
Reverts ankurk91/vue-cleave-component#16

Other sites does not support `vue` syntax highlighting.
Take this example -

https://www.npmjs.com/package/vue-multiselect
https://raw.githubusercontent.com/shentao/vue-multiselect/master/README.md

