### PR TITLE
Emit focus event

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -9,6 +9,7 @@ export default {
         value: this.value// Cleave.js will set this as initial value
       },
       on: {
+        focus: this.onFocus,
         blur: this.onBlur
       }
     })
@@ -73,6 +74,9 @@ export default {
       if (typeof this.onValueChangedFn === 'function') {
         this.onValueChangedFn.call(this, event)
       }
+    },
+    onFocus(event) {
+      this.$emit('focus', this.value)
     },
     onBlur(event) {
       this.$emit('blur', this.value)


### PR DESCRIPTION
Cleave components are currently emitting blur events, but not focus events. They should emit focus as well to match standard Cleave and input element behavior.