### PR TITLE
Fix delimiters not working

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -6,7 +6,7 @@ export default {
   render() {
     return h('input', {
       type: 'text',
-      value: this.modelValue,// Cleave.js will set this as initial value
+      value: this.cleave ? this.cleave.properties.result : this.modelValue,// Cleave.js will set this as initial value
       onBlur: this.onBlur,
       ref: 'root'
     })


### PR DESCRIPTION
Delimiters, and prefixes seems to be broken in Vue 3.

This fixes at least the delimiters, possibly also prefixes, but those are untested.